### PR TITLE
Modernize backend: CVE fixes, mongoose v7+ migration, DEMO_MODE, Render deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 CONNECTION_URI=mongodb+srv://user:password@cluster.mongodb.net/myFlixDB
 JWT_SECRET=replace-with-a-strong-random-string
 PORT=8080
+DEMO_MODE=false

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ CONNECTION_URI=mongodb+srv://user:password@cluster.mongodb.net/myFlixDB
 JWT_SECRET=replace-with-a-strong-random-string
 PORT=8080
 DEMO_MODE=false
+PUBLIC_BASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+CONNECTION_URI=mongodb+srv://user:password@cluster.mongodb.net/myFlixDB
+JWT_SECRET=replace-with-a-strong-random-string
+PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -3,6 +3,44 @@ API Documentation
 
 This API provides users with access to information about different movies, directors, and genres. Users are able to register and update their personal information as well as create and edit a list of their favorite movies.
 
+Stack: Node.js, Express, MongoDB (Mongoose), Passport (JWT + Local), Swagger.
+
+Local Development
+-----------------
+
+1.  Copy `.env.example` to `.env` and fill in values:
+
+    -   `CONNECTION_URI` — MongoDB connection string (e.g. an Atlas SRV URI)
+    -   `JWT_SECRET` — random string used to sign JWTs
+    -   `PORT` — defaults to `8080`
+    -   `DEMO_MODE` — set to `true` to run without a database, returning mock data on read endpoints and `503` on writes
+    -   `PUBLIC_BASE_URL` — optional, sets the deployed URL shown in the Swagger UI
+
+2.  Install dependencies:
+
+    ```
+    npm install --ignore-scripts
+    ```
+
+3.  Run the dev server with auto-reload:
+
+    ```
+    npm run dev
+    ```
+
+4.  Or run once:
+
+    ```
+    npm start
+    ```
+
+Swagger UI is served at `/api-docs`.
+
+Demo Mode
+---------
+
+Setting `DEMO_MODE=true` skips the MongoDB connection and serves a fixed set of mock movies from `demoData.js`. All authenticated write endpoints return `503 Demo mode: write operations disabled`. This lets the deployed app remain functional with no database.
+
 Table of Contents
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Demo Mode
 
 Setting `DEMO_MODE=true` skips the MongoDB connection and serves a fixed set of mock movies from `demoData.js`. All authenticated write endpoints return `503 Demo mode: write operations disabled`. This lets the deployed app remain functional with no database.
 
+Deploy to Render
+----------------
+
+This repo includes a `render.yaml` blueprint.
+
+1.  Push to GitHub.
+2.  In Render: New → Blueprint → connect this repo. Render reads `render.yaml` and creates the web service.
+3.  In the service's Environment tab, set the values marked `sync: false`:
+
+    -   `CONNECTION_URI` — MongoDB Atlas SRV string
+    -   `JWT_SECRET` — random string, at least 32 chars
+    -   `PUBLIC_BASE_URL` — after first deploy, set to `https://<service-name>.onrender.com` so Swagger points at the live API
+
+4.  Trigger a deploy. The service idles after 15 min of inactivity; cold-start on the next request takes ~30–60s.
+
 Table of Contents
 -----------------
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,20 @@
+TODO
+====
+
+Tests
+-----
+
+This project has no automated tests. The original CareerFoundry-era codebase shipped with none, and nothing existed to migrate.
+
+If/when tests are added, the modern stack would be:
+
+-   `supertest` for HTTP-level integration tests against the Express app
+-   `mongodb-memory-server` for an in-process Mongo instance, so tests don't depend on Atlas or a local mongod
+-   `jest` or `vitest` as the runner
+
+Suggested first targets:
+
+-   Auth flow: register → login → use JWT to read `/movies`
+-   `DEMO_MODE` smoke: every read endpoint returns mock data, every write returns `503`
+-   Validation: `POST /users` rejects bad usernames / emails
+-   Mongoose query shape: confirm `findOneAndUpdate({ new: true })` returns the updated doc (regression guard against the v7 callback-API break that this project recently survived)

--- a/auth.js
+++ b/auth.js
@@ -14,8 +14,15 @@ let generateJWTToken = (user) => {
 };
 
 /* POST login. */
+const DEMO_MODE = process.env.DEMO_MODE === "true";
+
 module.exports = (router) => {
   router.post("/login", (req, res) => {
+    if (DEMO_MODE) {
+      return res
+        .status(503)
+        .json({ message: "Demo mode: write operations disabled" });
+    }
     passport.authenticate("local", { session: false }, (error, user, info) => {
       if (error || !user) {
         return res.status(400).json({

--- a/auth.js
+++ b/auth.js
@@ -1,4 +1,4 @@
-const jwtSecret = "your_jwt_secret"; // This has to be the same key used in the JWTStrategy
+const jwtSecret = process.env.JWT_SECRET;
 
 const jwt = require("jsonwebtoken"),
   passport = require("passport");

--- a/demoData.js
+++ b/demoData.js
@@ -1,0 +1,130 @@
+const movies = [
+  {
+    _id: "demo-001",
+    Title: "The Godfather",
+    Description:
+      "The aging patriarch of an organized crime dynasty in postwar New York transfers control of his clandestine empire to his reluctant youngest son.",
+    Genre: {
+      Name: "Crime",
+      Description:
+        "Crime films focus on criminals, organized crime, and the morally ambiguous individuals who pursue or evade them.",
+    },
+    Director: {
+      Name: "Francis Ford Coppola",
+      Bio: "American film director, producer, and screenwriter, born April 7, 1939. Coppola is widely considered one of the most influential filmmakers of the New Hollywood era.",
+    },
+    Actors: ["Marlon Brando", "Al Pacino", "James Caan"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/3bhkrj58Vtu7enYsRolD1fZdja1.jpg",
+    Featured: true,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/tmU7GeKVybMWFButWEGl2M4GeiP.jpg",
+  },
+  {
+    _id: "demo-002",
+    Title: "The Shawshank Redemption",
+    Description:
+      "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.",
+    Genre: {
+      Name: "Drama",
+      Description:
+        "Drama films are serious presentations or stories with settings that portray realistic characters in conflict with themselves, others, or forces of nature.",
+    },
+    Director: {
+      Name: "Frank Darabont",
+      Bio: "Hungarian-American film director, screenwriter, and producer, born January 28, 1959. Best known for his adaptations of Stephen King novels.",
+    },
+    Actors: ["Tim Robbins", "Morgan Freeman", "Bob Gunton"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/q6y0Go1tsGEsmtFryDOJo3dEmqu.jpg",
+    Featured: true,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/iNh3BivHyg5sQRPP1KOkzguEX0H.jpg",
+  },
+  {
+    _id: "demo-003",
+    Title: "The Dark Knight",
+    Description:
+      "When the menace known as the Joker wreaks havoc on Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.",
+    Genre: {
+      Name: "Action",
+      Description:
+        "Action films are characterized by physical feats, fight sequences, chases, and large-scale battles, where the protagonist is thrust into a series of high-stakes events.",
+    },
+    Director: {
+      Name: "Christopher Nolan",
+      Bio: "British-American filmmaker, born July 30, 1970. Known for his thematically and structurally ambitious films, including the Dark Knight trilogy, Inception, and Interstellar.",
+    },
+    Actors: ["Christian Bale", "Heath Ledger", "Aaron Eckhart"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/qJ2tW6WMUDux911r6m7haRef0WH.jpg",
+    Featured: true,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/hkBaDkMWbLaf8B1lsWsKX7Ew3Xq.jpg",
+  },
+  {
+    _id: "demo-004",
+    Title: "Pulp Fiction",
+    Description:
+      "The lives of two mob hitmen, a boxer, a gangster and his wife, and a pair of diner bandits intertwine in four tales of violence and redemption.",
+    Genre: {
+      Name: "Crime",
+      Description:
+        "Crime films focus on criminals, organized crime, and the morally ambiguous individuals who pursue or evade them.",
+    },
+    Director: {
+      Name: "Quentin Tarantino",
+      Bio: "American filmmaker, born March 27, 1963. Known for his nonlinear storytelling, stylized violence, and references to popular culture.",
+    },
+    Actors: ["John Travolta", "Uma Thurman", "Samuel L. Jackson"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg",
+    Featured: false,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/4cDFJr4HnXN5AdPw4AKrmLlMWdO.jpg",
+  },
+  {
+    _id: "demo-005",
+    Title: "Inception",
+    Description:
+      "A thief who steals corporate secrets through dream-sharing technology is given the inverse task of planting an idea into the mind of a CEO.",
+    Genre: {
+      Name: "Sci-Fi",
+      Description:
+        "Science fiction films use speculative, fictional science-based depictions of phenomena that are not fully accepted by mainstream science.",
+    },
+    Director: {
+      Name: "Christopher Nolan",
+      Bio: "British-American filmmaker, born July 30, 1970. Known for his thematically and structurally ambitious films, including the Dark Knight trilogy, Inception, and Interstellar.",
+    },
+    Actors: ["Leonardo DiCaprio", "Joseph Gordon-Levitt", "Elliot Page"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg",
+    Featured: true,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/s3TBrRGB1iav7gFOCNx3H31MoES.jpg",
+  },
+  {
+    _id: "demo-006",
+    Title: "The Matrix",
+    Description:
+      "A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.",
+    Genre: {
+      Name: "Sci-Fi",
+      Description:
+        "Science fiction films use speculative, fictional science-based depictions of phenomena that are not fully accepted by mainstream science.",
+    },
+    Director: {
+      Name: "Lana Wachowski",
+      Bio: "American film director, writer, and producer, born June 21, 1965. Co-directed The Matrix franchise with her sister Lilly Wachowski.",
+    },
+    Actors: ["Keanu Reeves", "Laurence Fishburne", "Carrie-Anne Moss"],
+    ImagePath:
+      "https://image.tmdb.org/t/p/w500/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
+    Featured: false,
+    BackdropImage:
+      "https://image.tmdb.org/t/p/original/fNG7i7RqMErkcqhohV2a6cV1Ehy.jpg",
+  },
+];
+
+module.exports = { movies };

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ const swaggerOptions = {
     },
     servers: [
       {
-        url: "https://my-flix-db-jd.herokuapp.com",
+        url:
+          process.env.PUBLIC_BASE_URL ||
+          `http://localhost:${process.env.PORT || 8080}`,
       },
     ],
     tags: [

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 require("dotenv").config();
 
+const DEMO_MODE = process.env.DEMO_MODE === "true";
+const demoData = require("./demoData");
+
 const express = require("express"),
   app = express(),
   morgan = require("morgan"),
@@ -186,7 +189,9 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 //   useUnifiedTopology: true,
 // });
 
-mongoose.connect(process.env.CONNECTION_URI);
+if (!DEMO_MODE) {
+  mongoose.connect(process.env.CONNECTION_URI);
+}
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -223,6 +228,16 @@ app.use(
 let auth = require("./auth")(app);
 const passport = require("passport");
 require("./passport");
+
+const requireAuth = DEMO_MODE
+  ? (req, res, next) => next()
+  : passport.authenticate("jwt", { session: false });
+const demoBlock = (req, res, next) =>
+  DEMO_MODE
+    ? res
+        .status(503)
+        .json({ message: "Demo mode: write operations disabled" })
+    : next();
 
 //returns a welcome message
 app.get("/", (req, res) => {
@@ -266,8 +281,9 @@ app.get("/", (req, res) => {
  */
 app.get(
   "/movies",
-  passport.authenticate("jwt", { session: false }),
+  requireAuth,
   (req, res) => {
+    if (DEMO_MODE) return res.json(demoData.movies);
     Movies.find()
       .then((movies) => {
         res.status(200).json(movies);
@@ -305,8 +321,14 @@ app.get(
  */
 app.get(
   "/movies/:title",
-  passport.authenticate("jwt", { session: false }),
+  requireAuth,
   (req, res) => {
+    if (DEMO_MODE) {
+      const movie = demoData.movies.find(
+        (m) => m.Title.toLowerCase() === req.params.title.toLowerCase()
+      );
+      return res.json(movie || null);
+    }
     //res.send(`Got a GET request at /movies/title/${req.params.name}`);
 
     const title = req.params.title;
@@ -359,8 +381,14 @@ app.get(
  */
 app.get(
   "/movies/genres/:name",
-  passport.authenticate("jwt", { session: false }),
+  requireAuth,
   (req, res) => {
+    if (DEMO_MODE) {
+      const match = demoData.movies.find(
+        (m) => m.Genre.Name.toLowerCase() === req.params.name.toLowerCase()
+      );
+      return res.json(match ? match.Genre.Description : null);
+    }
     //res.send(`Got a GET request at /movies/genres/${req.params.name}`);
 
     const genreName = req.params.name;
@@ -413,8 +441,14 @@ app.get(
  */
 app.get(
   "/movies/directors/:name",
-  passport.authenticate("jwt", { session: false }),
+  requireAuth,
   (req, res) => {
+    if (DEMO_MODE) {
+      const match = demoData.movies.find(
+        (m) => m.Director.Name.toLowerCase() === req.params.name.toLowerCase()
+      );
+      return res.json(match ? match.Director.Bio : null);
+    }
     //res.send(`Got a GET request at /movies/directors/${req.params.name}`);
 
     const directorName = req.params.name;
@@ -496,7 +530,8 @@ app.get(
  */
 app.get(
   "/users",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     Users.find()
       .then((users) => {
@@ -535,7 +570,8 @@ app.get(
  */
 app.get(
   "/users/:Username",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     //res.send(`Got a GET request at /users/Username/${req.params.name}`);
 
@@ -584,6 +620,7 @@ app.get(
  */
 app.post(
   "/users",
+  demoBlock,
   [
     check("Username", "Username is required").isLength({ min: 5 }),
     check(
@@ -654,7 +691,8 @@ app.post(
  */
 app.delete(
   "/users/:Username",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     Users.findOneAndDelete({ Username: req.params.Username })
       .then((user) => {
@@ -776,6 +814,7 @@ app.delete(
  */
 app.put(
   "/users/:Username",
+  demoBlock,
   [
     check("Username", "Username is required").isLength({ min: 5 }),
     check(
@@ -784,7 +823,7 @@ app.put(
     ).isAlphanumeric(),
     check("Email", "Email does not appear to be valid").isEmail(),
   ],
-  passport.authenticate("jwt", { session: false }),
+  requireAuth,
   (req, res) => {
     // check the validation object for errors
     let errors = validationResult(req);
@@ -881,7 +920,7 @@ app.put(
  *         username: johnDoe
  *         password: p@ssw0rd
  */
-app.post("/verify-password", (req, res) => {
+app.post("/verify-password", demoBlock, (req, res) => {
   Users.findOne({ Username: req.body.username })
     .then((user) => {
       if (!user) {
@@ -941,7 +980,8 @@ app.post("/verify-password", (req, res) => {
  */
 app.get(
   "/users/:Username/favorites",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     Users.findOne({ Username: req.params.Username })
       .populate("FavoriteMovies")
@@ -1006,7 +1046,8 @@ app.get(
  */
 app.post(
   "/users/:Username/movies/:MovieID",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     Users.findOneAndUpdate(
       { Username: req.params.Username },
@@ -1076,7 +1117,8 @@ app.post(
  */
 app.delete(
   "/users/:Username/movies/:MovieID",
-  passport.authenticate("jwt", { session: false }),
+  demoBlock,
+  requireAuth,
   (req, res) => {
     Users.findOneAndUpdate(
       { Username: req.params.Username },

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@ require("dotenv").config();
 
 const express = require("express"),
   app = express(),
-  bodyParser = require("body-parser"),
-  uuid = require("uuid"),
   morgan = require("morgan"),
   mongoose = require("mongoose"),
   Models = require("./models.js"),
@@ -190,8 +188,8 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 
 mongoose.connect(process.env.CONNECTION_URI);
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true })); //bodyParser middleware function
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(morgan("common"));
 app.use(express.static("public"));
 //app.use(cors()); //allow requests from all origins

--- a/index.js
+++ b/index.js
@@ -188,10 +188,7 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 //   useUnifiedTopology: true,
 // });
 
-mongoose.connect(process.env.CONNECTION_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
+mongoose.connect(process.env.CONNECTION_URI);
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true })); //bodyParser middleware function
@@ -661,7 +658,7 @@ app.delete(
   "/users/:Username",
   passport.authenticate("jwt", { session: false }),
   (req, res) => {
-    Users.findOneAndRemove({ Username: req.params.Username })
+    Users.findOneAndDelete({ Username: req.params.Username })
       .then((user) => {
         if (!user) {
           res.status(400).send(req.params.Username + " was not found.");
@@ -814,17 +811,15 @@ app.put(
     Users.findOneAndUpdate(
       { Username: req.params.Username },
       { $set: updateFields },
-      { new: true }, // This line makes sure that the updated document is returned
-      //error..
-      (error, updatedUser) => {
-        if (error) {
-          console.error(error);
-          res.status(500).send("Error: " + error);
-        } else {
-          res.json(updatedUser);
-        }
-      }
-    );
+      { new: true }
+    )
+      .then((updatedUser) => {
+        res.json(updatedUser);
+      })
+      .catch((error) => {
+        console.error(error);
+        res.status(500).send("Error: " + error);
+      });
   }
 );
 
@@ -889,24 +884,22 @@ app.put(
  *         password: p@ssw0rd
  */
 app.post("/verify-password", (req, res) => {
-  // Find the user with the specified username
-  Users.findOne({ Username: req.body.username }, (err, user) => {
-    if (err) {
+  Users.findOne({ Username: req.body.username })
+    .then((user) => {
+      if (!user) {
+        return res.status(404).send("User not found");
+      }
+      let isValid = user.validatePassword(req.body.password);
+      if (!isValid) {
+        return res.status(401).send("Incorrect password");
+      }
+      res.set("Access-Control-Allow-Origin", "*");
+      return res.status(200).send({ success: true });
+    })
+    .catch((err) => {
       console.error(err);
       return res.status(500).send("Error: " + err);
-    }
-    if (!user) {
-      return res.status(404).send("User not found");
-    }
-    // Use the validatePassword method to check if the entered password is correct
-    let isValid = user.validatePassword(req.body.password);
-    if (!isValid) {
-      return res.status(401).send("Incorrect password");
-    }
-    // If the password is correct, set the Access-Control-Allow-Origin header and return a success message
-    res.set("Access-Control-Allow-Origin", "*");
-    return res.status(200).send({ success: true });
-  });
+    });
 });
 
 // Get a user's favorite movies
@@ -1022,17 +1015,15 @@ app.post(
       {
         $push: { FavoriteMovies: req.params.MovieID },
       },
-      { new: true }, // This line makes sure that the updated document is returned
-      //error..
-      (error, updatedUser) => {
-        if (error) {
-          console.error(error);
-          res.status(500).send("Error: " + error);
-        } else {
-          res.json(updatedUser);
-        }
-      }
-    );
+      { new: true }
+    )
+      .then((updatedUser) => {
+        res.json(updatedUser);
+      })
+      .catch((error) => {
+        console.error(error);
+        res.status(500).send("Error: " + error);
+      });
   }
 );
 
@@ -1094,17 +1085,15 @@ app.delete(
       {
         $pull: { FavoriteMovies: req.params.MovieID },
       },
-      { new: true }, // This line makes sure that the updated document is returned
-      //error..
-      (error, updatedUser) => {
-        if (error) {
-          console.error(error);
-          res.status(500).send("Error: " + error);
-        } else {
-          res.json(updatedUser);
-        }
-      }
-    );
+      { new: true }
+    )
+      .then((updatedUser) => {
+        res.json(updatedUser);
+      })
+      .catch((error) => {
+        console.error(error);
+        res.status(500).send("Error: " + error);
+      });
   }
 );
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 const express = require("express"),
   app = express(),
   bodyParser = require("body-parser"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,21 +11,18 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^4.21.2",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
-        "lodash": "^4.18.1",
         "mongoose": "^8.9.3",
         "morgan": "^1.10.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
         "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1",
-        "uuid": "^11.0.3"
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
@@ -2060,19 +2057,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.20.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.20.2.tgz",
-      "integrity": "sha512-U0TPupnqBOAI3p9H9qdShX8/nJUBylliRcHFKuhbewEkM7Y0qc9BbrQR9h4q6+1easoZqej7cq2Ee36AZ0gMzQ==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.1.tgz",
+      "integrity": "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -2050,9 +2050,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcrypt": "^6.0.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "express": "^4.21.2",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
@@ -439,6 +440,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -22,21 +22,18 @@
   "homepage": "https://github.com/jdussold/movie_api#readme",
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.21.2",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
-    "lodash": "^4.18.1",
     "mongoose": "^8.9.3",
     "morgan": "^1.10.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1",
-    "uuid": "^11.0.3"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bcrypt": "^6.0.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.2",
     "express": "^4.21.2",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",

--- a/passport.js
+++ b/passport.js
@@ -30,20 +30,22 @@ passport.use(
   )
 );
 
-passport.use(
-  new JWTStrategy(
-    {
-      jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.JWT_SECRET,
-    },
-    (jwtPayload, callback) => {
-      return Users.findById(jwtPayload._id)
-        .then((user) => {
-          return callback(null, user);
-        })
-        .catch((error) => {
-          return callback(error);
-        });
-    }
-  )
-);
+if (process.env.JWT_SECRET) {
+  passport.use(
+    new JWTStrategy(
+      {
+        jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+        secretOrKey: process.env.JWT_SECRET,
+      },
+      (jwtPayload, callback) => {
+        return Users.findById(jwtPayload._id)
+          .then((user) => {
+            return callback(null, user);
+          })
+          .catch((error) => {
+            return callback(error);
+          });
+      }
+    )
+  );
+}

--- a/passport.js
+++ b/passport.js
@@ -42,7 +42,7 @@ passport.use(
   new JWTStrategy(
     {
       jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
-      secretOrKey: "your_jwt_secret",
+      secretOrKey: process.env.JWT_SECRET,
     },
     (jwtPayload, callback) => {
       return Users.findById(jwtPayload._id)

--- a/passport.js
+++ b/passport.js
@@ -13,27 +13,19 @@ passport.use(
       usernameField: "Username",
       passwordField: "Password",
     },
-    (username, password, callback) => {
-      console.log(username + "  " + password);
-      Users.findOne({ Username: username }, (error, user) => {
-        if (error) {
-          console.log(error);
-          return callback(error);
-        }
-
+    async (username, password, callback) => {
+      try {
+        const user = await Users.findOne({ Username: username });
         if (!user) {
-          console.log("incorrect username");
           return callback(null, false, { message: "Incorrect username." });
         }
-
         if (!user.validatePassword(password)) {
-          console.log("incorrect password");
           return callback(null, false, { message: "Incorrect password." });
         }
-
-        console.log("finished");
         return callback(null, user);
-      });
+      } catch (error) {
+        return callback(error);
+      }
     }
   )
 );

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,19 @@
+services:
+  - type: web
+    name: movie-api
+    runtime: node
+    plan: free
+    buildCommand: npm install --ignore-scripts && find node_modules -path '*/.claude' -type d -exec rm -rf {} +
+    startCommand: node index.js
+    healthCheckPath: /
+    envVars:
+      - key: NODE_VERSION
+        value: 22.11.0
+      - key: CONNECTION_URI
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+      - key: DEMO_MODE
+        value: "false"
+      - key: PUBLIC_BASE_URL
+        sync: false


### PR DESCRIPTION
## Summary

**Security**

- Patches two pre-existing advisories: mongoose NoSQL injection (`$nor` in `sanitizeFilter`) and uuid buffer bounds check.
- Removes hardcoded JWT signing secret from source. Secret is now read from `JWT_SECRET` env var. The previous value (`"your_jwt_secret"`, a placeholder from the original tutorial) had been visible in git history, so JWTs signed against the live deployment must be considered compromised — see test plan.

**Bug fixes**

- Migrates remaining mongoose callback-API usage to promises. The most consequential fix is in `passport.js` LocalStrategy — the prior callback-style `Users.findOne` had been silently broken since the mongoose v7 upgrade, breaking login.
- Replaces `findOneAndRemove` (removed in mongoose 7) with `findOneAndDelete`.

**Cleanup**

- Drops `body-parser`, `lodash`, and `uuid` (unused or replaced by built-ins).
- Parameterizes the Swagger server URL via `PUBLIC_BASE_URL`; removes hardcoded Heroku reference.

**New**

- `DEMO_MODE` flag: read endpoints serve fixtures from `demoData.js`, write endpoints return `503`. Lets the deployed app stay functional even when the Atlas cluster is paused.
- `render.yaml` blueprint for free-tier deploy.
- `.env.example`, `TODO.md`, and a Local Development section in the README.

## Test plan

- [x] \`npm audit\` — 0 vulnerabilities
- [x] \`npm audit signatures\` — all verified
- [x] \`node --check\` on all source files
- [x] DEMO_MODE smoke (read endpoints return mock data, writes return 503)
- [ ] Live mode smoke against reactivated Atlas cluster
- [ ] Render deploy verified end-to-end after merge
- [ ] **Rotate JWT secret in any live environment** (Heroku, then Render). Old secret is in git history; existing user sessions should be invalidated.